### PR TITLE
Feature/cinepass filter toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ next-env.d.ts
 
 # IntelliJ
 /.idea/
+
+# MEMORY
+MEMORY.md 

--- a/src/app/(calendrier)/calendar-filters.tsx
+++ b/src/app/(calendrier)/calendar-filters.tsx
@@ -34,7 +34,7 @@ export default function CalendarFilters({
                   isOpen={isQuartierSelectorOpen}
                 />
               </div>
-              <div className="flex w-225px">
+              <div className="flex w-[465px] gap-x-15px">
                 <Events />
               </div>
               <div className="flex grow">
@@ -48,16 +48,14 @@ export default function CalendarFilters({
             )}
           </div>
           <div className="lg:hidden">
-            <div className="grid grow grid-cols-[repeat(auto-fill,_minmax(40%,_1fr))] gap-x-15px">
+            <div className="grid grow grid-cols-[repeat(auto-fill,_minmax(40%,_1fr))] gap-x-15px gap-y-10px">
               <div className="flex">
                 <QuartierSelectorToggler
                   toggleOpen={toggleQuartierSelectorOpen}
                   isOpen={isQuartierSelectorOpen}
                 />
               </div>
-              <div className="flex">
-                <Events />
-              </div>
+              <Events />
             </div>
             {isQuartierSelectorOpen && (
               <div className="flex pt-8px">
@@ -70,8 +68,8 @@ export default function CalendarFilters({
           </div>
         </>
       ) : (
-        <div className="flex flex-col gap-x-15px lg:flex-row">
-          <div className="flex w-225px">
+        <div className="flex flex-col gap-15px lg:flex-row">
+          <div className="flex w-[465px] gap-x-15px">
             <Events />
           </div>
           <div className="flex grow pt-15px lg:pt-0">

--- a/src/app/(calendrier)/events.tsx
+++ b/src/app/(calendrier)/events.tsx
@@ -10,27 +10,56 @@ import { useCalendrierStore } from "@/lib/calendrier-store";
 export default function Events() {
   const isEventsClicked = useCalendrierStore((s) => s.events);
   const toggleEvents = useCalendrierStore((s) => s.toggleEvents);
-  const onClick = useCallback(
+  const isCinepassClicked = useCalendrierStore((s) => s.cinepassOnly);
+  const toggleCinepassOnly = useCalendrierStore((s) => s.toggleCinepassOnly);
+
+  const onClickEvents = useCallback(
     () => toggleEvents(isEventsClicked),
     [isEventsClicked, toggleEvents],
   );
+
+  const onClickCinepass = useCallback(
+    () => toggleCinepassOnly(),
+    [toggleCinepassOnly],
+  );
+
   return (
-    <TextBox
-      className={clsx(
-        {
-          "border-retro-gray": !isEventsClicked,
-          "text-retro-gray": !isEventsClicked,
-        },
-        {
-          "bg-retro-gray": isEventsClicked,
-          "text-white": isEventsClicked,
-        },
-        "h-42px lg:h-48px",
-      )}
-      onClick={onClick}
-    >
-      <ButtonCopy className="lg:hidden">Séances spéc.</ButtonCopy>
-      <ButtonCopy className="hidden lg:block">Séances spéciales</ButtonCopy>
-    </TextBox>
+    <>
+      <TextBox
+        className={clsx(
+          {
+            "border-retro-gray": !isEventsClicked,
+            "text-retro-gray": !isEventsClicked,
+          },
+          {
+            "bg-retro-gray": isEventsClicked,
+            "text-white": isEventsClicked,
+          },
+          "h-42px flex-1 lg:h-48px",
+        )}
+        onClick={onClickEvents}
+      >
+        <ButtonCopy className="lg:hidden">Séances spéc.</ButtonCopy>
+        <ButtonCopy className="hidden lg:block">Séances spéciales</ButtonCopy>
+      </TextBox>
+
+      <TextBox
+        className={clsx(
+          {
+            "border-retro-gray": !isCinepassClicked,
+            "text-retro-gray": !isCinepassClicked,
+          },
+          {
+            "bg-retro-gray": isCinepassClicked,
+            "text-white": isCinepassClicked,
+          },
+          "h-42px flex-1 lg:h-48px",
+        )}
+        onClick={onClickCinepass}
+      >
+        <ButtonCopy className="lg:hidden">Cinépass</ButtonCopy>
+        <ButtonCopy className="hidden lg:block">Cinépass Pathé</ButtonCopy>
+      </TextBox>
+    </>
   );
 }

--- a/src/app/(calendrier)/movie-table.tsx
+++ b/src/app/(calendrier)/movie-table.tsx
@@ -20,6 +20,7 @@ import {
 import {
   checkNotNull,
   fetcher,
+  filterCinepass,
   filterDates,
   filterNeighborhoods,
   filterTimes,
@@ -53,6 +54,7 @@ export default function MovieTable({
   const filter = useCalendrierStore((s) => s.filter);
   const quartiers = useCalendrierStore((s) => s.quartiers);
   const events = useCalendrierStore((s) => s.events);
+  const cinepassOnly = useCalendrierStore((s) => s.cinepassOnly);
 
   const url = marseille
     ? allMovies
@@ -111,6 +113,7 @@ export default function MovieTable({
               quartiers,
               filter,
               events,
+              cinepassOnly,
             }}
             date={date}
           />
@@ -130,6 +133,7 @@ function LoadedTable({
   quartiers,
   filter,
   events,
+  cinepassOnly,
   date,
 }: {
   serverMovies: Promise<
@@ -142,6 +146,7 @@ function LoadedTable({
   quartiers: Quartier[];
   filter: string;
   events: boolean;
+  cinepassOnly: boolean;
   date?: DateTime;
 }) {
   const serverMovies = use(serverMoviesPromise);
@@ -159,6 +164,7 @@ function LoadedTable({
         quartiers,
         filter,
         events,
+        cinepassOnly,
       ),
     [
       movies,
@@ -167,6 +173,7 @@ function LoadedTable({
       quartiers,
       filter,
       events,
+      cinepassOnly,
     ],
   );
 
@@ -299,6 +306,7 @@ function filterAndSortMovies(
   quartiers: Quartier[],
   filterQuery: string,
   events: boolean,
+  cinepassOnly: boolean,
 ) {
   const moviesWithFilteredShowtimes = isMoviesWithShowtimesSeveralDays(movies)
     ? movies
@@ -308,9 +316,12 @@ function filterAndSortMovies(
             Object.entries(movie.showtimes_by_day)
               .map(([day, showtimes]) => [
                 day,
-                filterNeighborhoods(
-                  filterTimes(showtimes, 0, 24, events),
-                  quartiers,
+                filterCinepass(
+                  filterNeighborhoods(
+                    filterTimes(showtimes, 0, 24, events),
+                    quartiers,
+                  ),
+                  cinepassOnly,
                 ),
               ])
               .filter(([_, showtimes]) => showtimes.length > 0),
@@ -328,14 +339,17 @@ function filterAndSortMovies(
     : movies
         .map<MovieWithScreeningsOneDay>((movie) => ({
           ...movie,
-          showtimes_theater: filterNeighborhoods(
-            filterTimes(
-              movie.showtimes_theater,
-              minHourFilteringTodaysMissedFilms,
-              maxHour,
-              events,
+          showtimes_theater: filterCinepass(
+            filterNeighborhoods(
+              filterTimes(
+                movie.showtimes_theater,
+                minHourFilteringTodaysMissedFilms,
+                maxHour,
+                events,
+              ),
+              quartiers,
             ),
-            quartiers,
+            cinepassOnly,
           ),
         }))
         .filter((movie) => movie.showtimes_theater.length > 0);

--- a/src/lib/calendrier-store.tsx
+++ b/src/lib/calendrier-store.tsx
@@ -24,12 +24,14 @@ interface CalendrierState {
   filter: string;
   quartiers: Quartier[];
   events: boolean;
+  cinepassOnly: boolean;
   setDate: (date: DateTime) => void;
   setMinHour: (minHour: number) => void;
   setMaxHour: (maxHour: number) => void;
   setFilter: (filter: string) => void;
   toggleQuartier: (quartier: Quartier) => void;
   toggleEvents: (events: boolean) => void;
+  toggleCinepassOnly: () => void;
   reset: () => void;
 }
 
@@ -42,6 +44,7 @@ export function getUseCalendrierStore() {
     filter: "",
     quartiers: [],
     events: false,
+    cinepassOnly: false,
     setDate: (date: DateTime) => {
       set({ date, dateChanged: true });
     },
@@ -57,6 +60,8 @@ export function getUseCalendrierStore() {
       }
     },
     toggleEvents: (events: boolean) => set({ events: !events }),
+    toggleCinepassOnly: () =>
+      set((state) => ({ cinepassOnly: !state.cinepassOnly })),
     reset: () => {
       set({
         date: getStartOfTodayInParis(),
@@ -66,6 +71,7 @@ export function getUseCalendrierStore() {
         filter: "",
         quartiers: [],
         events: false,
+        cinepassOnly: false,
       });
     },
   }));

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -66,6 +66,7 @@ export interface TheaterScreenings {
   zipcode: string;
   name: string;
   preposition_and_name: string;
+  isPathe?: boolean;
 }
 
 export interface SearchTheater {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -229,6 +229,91 @@ export function filterNeighborhoods(
   );
 }
 
+export const CINEPASS_THEATERS = [
+  "3 Cinés Robespierre",
+  "4 Delta",
+  "5 Caumartin",
+  "7 Batignolles",
+  "Sept Parnassiens",
+  "Le Balzac", // Confirmé fonctionnel + vérifié sur leur site
+  "Chaplin Denfert",
+  "Cinéma Chaplin Saint Lambert", // Confirmé fonctionnel + vérifié sur leur site
+  "Christine Cinéma Club", // Confirmé fonctionnel + vérifié sur leur site
+  "Cinémassy", // Confirmé fonctionnel + vérifié sur leur site
+  "Le Cinéma des Cinéastes",
+  "Cinéma du Panthéon", // Confirmé fonctionnel + vérifié sur leur site
+  "Cinéma Landowski",
+  "Mac-Mahon", // Confirmé fonctionnel + vérifié sur leur site
+  "Écoles 21",
+  "Elysées Lincoln",
+  "Épée de Bois", // Confirmé fonctionnel + vérifié sur leur site
+  "Espace 1789", // Vérifié sur leur site
+  "Espace Saint-Michel", // Confirmé fonctionnel + vérifié sur leur site
+  "Écoles Cinéma Club", // Confirmé fonctionnel + vérifié sur leur site
+  "Filmothèque du Quartier Latin", // Confirmé fonctionnel + vérifié sur leur site
+  "Gaumont Disney Village",
+  "La Géode",
+  "La Pléiade",
+  "Le Brady",
+  "Le Capitole",
+  "Le Grand Action", // Confirmé fonctionnel + vérifié sur leur site
+  "Le Jeu de Paume",
+  "Le Lido",
+  "Le Lucernaire",
+  "Saint-André des Arts", // Confirmé fonctionnel + vérifié sur leur site
+  "L'Ecran",
+  "L'Entrepôt", // Confirmé fonctionnel + vérifié sur leur site
+  "Les 3 Luxembourg", // Confirmé fonctionnel + vérifié sur leur site
+  "Les 3 Pierrots - St Cloud",
+  "Les Capucins",
+  "Luminor Hôtel de Ville", // Confirmé fonctionnel mais pas présent sur leur site : https://www.luminor-hoteldeville.com/
+  "Max Linder Panorama", // Confirmé fonctionnel + vérifié sur leur site
+  "Nouvel Odéon", // Confirmé fonctionnel + vérifié sur leur site
+  "Pathé Aéroville",
+  "Gaumont Alésia",
+  "Pathé Aquaboulevard",
+  "Pathé Beaugrenelle",
+  "Pathé Belle Epine",
+  "Pathé BNP Paribas",
+  "Pathé Boulogne",
+  "Pathé Carré Sénart",
+  "Pathé Conflans",
+  "Pathé Convention",
+  "Pathé Dammarie",
+  "Pathé La villette",
+  "Pathé Les Fauvettes",
+  "Pathé Levallois",
+  "Pathé Massy",
+  "Pathé Montparnos",
+  "Pathé Palace",
+  "Pathé Parnasse",
+  "Pathé Quai d'Ivry",
+  "Pathé Saint Denis",
+  "Pathé Wepler",
+  "Publicis Cinémas", // Confirmé fonctionnel + vérifié sur leur site
+  "Studio des Ursulines",
+  "L'Archipel", // Confirmé fonctionnel + vérifié sur leur site
+  "Majestic Bastille",
+  "Majestic Passy",
+  "L'Escurial Panorama",
+  // "Reflet Médicis",                 // Confirmé fonctionnel mais pas présent sur leur site : https://dulaccinemas.com/infos-pratiques
+  "L'Arlequin",
+];
+
+export function filterCinepass(
+  showtimes: TheaterScreenings[],
+  cinepassOnly: boolean,
+) {
+  if (!cinepassOnly) return showtimes;
+  return showtimes.filter((theater) =>
+    some(
+      CINEPASS_THEATERS,
+      (cinepassTheater) =>
+        cinepassTheater.toLowerCase() === theater.name.toLowerCase(),
+    ),
+  );
+}
+
 export function filterDates(showtimes: {
   [date: string]: TheaterScreenings[];
 }) {


### PR DESCRIPTION
## What does this PR do

This PR introduces a new toggle in the calendar filters to display only movies screening in theaters that accept the "Cinépass Pathé". Since I cannot modify the external data scraper, this filtering logic is implemented entirely on the frontend by matching theater names against a hardcoded list. The list of theaters that accept the Cinépass can be found here: https://media.pathe.fr/files/conditions/ReseauCinePassCineCartes.pdf
_(I checked that the name of the theaters matches exactly those on the lists, but only with the movie theater names availible. If some movie theaters are not appearing on the calendar list, I cannot be sure that the names are exactly correct. Those I checked are commented with `// Confirmé fonctionnel + vérifié sur leur site`, the `Confirmé fonctionnel` means that the name is correct and the `vérifié sur leur site` means that I checked on the theater website if they do accept the Cinépass card)._
Also, I'm going to add the same for UGC cards later on.

## Why this change
I want the ability to quickly filter out theaters that are not compatible with the Cinépass subscription. This improves the UX by allowing me to find relevant screenings faster.

## Implementation Details:

Store update (calendrier-store.tsx): 

- Added cinepassOnly boolean state and toggleCinepassOnly action to Zustand.

Filtering logic (utils.ts):

- Created a CINEPASS_THEATERS constant containing the list of eligible theaters.
- Added the filterCinepass function to filter the TheaterScreenings array based on the store's state.
- Injected this filter into the existing filterAndSortMovies data pipeline (movie-table.tsx).

UI adjustments (events.tsx & calendar-filters.tsx):

- Replicated the "Séances spéciales" button design for the new "Cinépass Pathé" toggle.
- Converted the Events component to return a React Fragment.
- Adjusted the CSS Grid on mobile so the "Cinépass Pathé" button wraps to a new line and aligns perfectly to the left under the neighborhood selector, preventing any overflow. Extended the flex container width on desktop to comfortably fit both buttons side-by-side.

## How to Test
Start the development server (`pnpm run dev`).
Navigate to the calendar view (http://localhost:3000/).
Observe the new "Cinépass Pathé" button next to "Séances spéciales".

- Desktop: Ensure both buttons sit nicely side-by-side.
- Mobile: Ensure the "Cinépass" button drops down to a new row and aligns to the left edge of the screen.

Click the toggle and verify that only movies playing in the list are displayed (in this case the movies in mk2 theaters are not present for example).

## Running `pnpm run dev`
```
   ▲ Next.js 15.1.11
   - Experiments (use with caution):
     · reactCompiler

   Creating an optimized production build ...
 ✓ Compiled successfully
 ✓ Linting and checking validity of types
 ✓ Collecting page data
 ✓ Generating static pages (43/43)
 ✓ Collecting build traces
 ✓ Finalizing page optimization
```